### PR TITLE
fix test for json reader; try circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.12
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go install
+      - run: go test -v ./...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ brews:
     github:
       owner: pburakov
       name: homebrew-io
+    homepage: "https://github.com/pburakov/playback/"
+    description: "CLI tool for replaying events from local file into PubSub topic in real-time."
     commit_author:
       name: Paul Burakov
       email: pburakov@gmail.com

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ It is important to note that all modes (and instant mode is the most vulnerable)
 ## Known Bugs and Limitations
 
 - Using timestamp field within a nested structure is not currently supported.
+- Last message in JSON files will be skipped if there's no newline delimiter at the EOF. 
 
 ## Supported Formats
 

--- a/input/json/json_test.go
+++ b/input/json/json_test.go
@@ -24,7 +24,7 @@ func TestInitAndReadLines(t *testing.T) {
 
 	ts, l, e := r.ReadLineWithTS()
 
-	expected := `{"foo":"1","bar":"2019-02-11T15:20:09.514626","baz":["1","2","3"],"faz":{"A":"foo","B":42.42}}`
+	expected := `{"foo":"1","bar":"2019-02-11T15:20:09.514626","baz":["1","2","3"],"faz":{"A":"foo","B":42.42}}` + "\n"
 
 	assert.NoError(t, e)
 	assert.Equal(t, time.Date(2019, 02, 11, 15, 20, 9, 514626000, time.UTC), ts)
@@ -32,7 +32,7 @@ func TestInitAndReadLines(t *testing.T) {
 
 	l, e = r.ReadLine()
 
-	expected = `{"foo":"2","bar":"2019-02-06T02:22:47.327394","baz":["4","5","6"],"faz":{"A":"moo","B":43.43}}`
+	expected = `{"foo":"2","bar":"2019-02-06T02:22:47.327394","baz":["4","5","6"],"faz":{"A":"moo","B":43.43}}` + "\n"
 
 	assert.NoError(t, e)
 	assert.Equal(t, expected, string(l))


### PR DESCRIPTION
- bufio includes buffer delimiter which breaks a test case; this is now fixed.
- try circle ci integration